### PR TITLE
Add opened .vue file to externalFiles

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -149,7 +149,13 @@ function init({ typescript: ts } : {typescript: typeof ts_module}) {
   }
 
   function getExternalFiles(project: ts_module.server.ConfiguredProject) {
-    return project.getFileNames().filter(interested);
+    const result = project.getFileNames().filter(interested);
+    project.projectService.openFiles.forEach((path, filename) => {
+      if (interested(filename)) {
+        result.push(ts.server.toNormalizedPath(filename));
+      }
+    });
+    return result;
   }
 }
 


### PR DESCRIPTION
Because vue file not imported from ts file are not included in project

(cherry picked from commit e4f7c8c932dbcba148f4853e1517b1981ea517cd)

---

This fixes the problem about imports not found as discussed in https://github.com/w0rp/ale/issues/927#issuecomment-473012298 and following.

Without it, imports of components in `.vue` components always triggered a `2307: Cannot find module '@/components/Component.vue'.` error.

With this change, imports now don't trigger an error anymore. Though it seems now *all* imports of `.vue` files are considered valid. E.g.:

```js
import NotExistent from "@/components/wrongNameComponent.vue"
// no linting error even though the file does not exist
```

Since the project won't compile with such an error though, I think this is more acceptable to not display a linting error in this case instead of displaying wrong linting errors for existing files.

Anyway, maybe somebody with more experience can take a look at the change and maybe see why now *all* imports are considered valid, not only existing ones?