### PR TITLE
feature: Add vue3 support

### DIFF
--- a/lib/typing.d.ts
+++ b/lib/typing.d.ts
@@ -1,7 +1,25 @@
-declare module 'vue-template-compiler' {
-    export function parseComponent(text: string, option: {pad: string}): {
-        script?: {
-            content: string
-        }
-    }
+declare module '@vue/compiler-sfc' {
+  export interface SFCParseOptions {
+    pad?: boolean | 'line' | 'space'
+  }
+
+  export interface SFCBlock {
+    content: string
+  }
+
+  export interface SFCScriptBlock extends SFCBlock {
+  }
+
+  export interface SFCDescriptor {
+    script: SFCScriptBlock | null
+  }
+
+  export interface SFCParseResult {
+    descriptor: SFCDescriptor
+  }
+
+  export function parse(
+    source: string,
+    options: SFCParseOptions 
+  ): SFCParseResult
 }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   },
   "homepage": "https://github.com/HerringtonDarkholme/vue-ts-plugin#readme",
   "devDependencies": {
-    "@types/node": "^7.0.5",
+    "@types/node": "7.0.5",
     "typescript": "^2.7.0"
   },
   "peer-dependencies": {
-    "vue-template-compiler": "*"
+    "@vue/compiler-sfc": "*"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "noImplicitAny": false,
         "strict": true,
         "sourceMap": false,
-        "outDir": "bin"
+        "outDir": "bin",
+        "skipLibCheck": true
     }
 }


### PR DESCRIPTION
+ Use `@vue/compiler-sfc` instead of `vue-template-compiler`.
+ Use `Vue.defineComponent({...})` instead of `New Vue({...})`

Maybe we can create a new `next` branch, and deploy the npm package with the `next` tag to remain the 
compatibility for vue2.
